### PR TITLE
fix: the signal parameter is invalid

### DIFF
--- a/packages/mst-advanced-demo/src/pages/list-page/index.tsx
+++ b/packages/mst-advanced-demo/src/pages/list-page/index.tsx
@@ -10,6 +10,7 @@ const Store = createListModel({
   }),
   onQuery: (signal: AbortSignal, params: any) => {
     console.log(signal, params);
+    signal.addEventListener('abort', () => console.log(1));
     return new Promise<{ total: number; data: Array<{ id: number; name: string }> }>((resolve) =>
       setTimeout(() => {
         resolve({
@@ -25,7 +26,7 @@ const Store = createListModel({
             },
           ],
         });
-      }, 1000),
+      }, 3000),
     );
   },
   onResult: (item) => ({

--- a/packages/mst-advanced/src/create-query-model.ts
+++ b/packages/mst-advanced/src/create-query-model.ts
@@ -25,9 +25,6 @@ export const createQueryModel = <
     errMsg: types.maybeNull(types.frozen()),
     status: types.optional(types.enumeration(Object.values(RequestStatus)), RequestStatus.PENDING),
   })
-    .volatile(() => ({
-      abortController: new AbortController(),
-    }))
     .views((t) => ({
       get loading() {
         return t.status === RequestStatus.PENDING;
@@ -37,10 +34,10 @@ export const createQueryModel = <
       },
     }))
     .actions((t) => ({
-      fetchData: flow(function* (params?) {
+      fetchData: flow(function* (signal: AbortSignal, params?) {
         t.status = RequestStatus.PENDING;
         try {
-          const res = yield* toGenerator(onQuery(t.abortController.signal, params));
+          const res = yield* toGenerator(onQuery(signal, params));
           onResult(t, res);
           t.status = RequestStatus.SUCCESS;
         } catch (err) {
@@ -48,10 +45,5 @@ export const createQueryModel = <
           t.status = RequestStatus.ERROR;
         }
       }),
-    }))
-    .actions((t) => ({
-      beforeDestroy() {
-        t.abortController.abort();
-      },
     }));
 };


### PR DESCRIPTION
Closed #1 

The original **abortController** created in the model is shared by all requests, and the request cannot be canceled.

Fixed this by changing where the **abortController** is created.

![screenshot-20221031-154907](https://user-images.githubusercontent.com/37237996/198961397-bd3da643-e5ef-43b9-8f3e-931f303c48c7.png)
